### PR TITLE
chore: use peer dependencies meta to mark some optional dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,23 @@
     "@wallet-standard/features": "^1.0.3",
     "viem": "^2.7.12"
   },
+  "peerDependenciesMeta": {
+    "viem": {
+      "optional": true
+    },
+    "@solana/web3.js": {
+      "optional": true
+    },
+    "@solana/wallet-standard-features": {
+      "optional": true
+    },
+    "@wallet-standard/features": {
+      "optional": true
+    },
+    "@wallet-standard/base": {
+      "optional": true
+    }
+  },
   "typesVersions": {
     "*": {
       "eip6963": [


### PR DESCRIPTION
Mark the following dependencies as optional because the package can function
without them, they will be installed by the consumer app
- viem
- @solana/web3.js
- @solana/wallet-standard-features
- @wallet-standard/features
- @wallet-standard/base