### PR TITLE
fix: use env id as eip-6963 uuid

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "build:cjs": "tsc --project ./tsconfig.json --module commonjs --moduleResolution node --outDir ./dist/cjs --removeComments --verbatimModuleSyntax false"
   },
   "dependencies": {
-    "@dynamic-labs/global-wallet-client": "^4.4.3",
+    "@dynamic-labs/global-wallet-client": "^4.9.9",
     "@wallet-standard/wallet": "^1.1.0"
   },
   "devDependencies": {

--- a/src/lib/EIP6963Emitter.ts
+++ b/src/lib/EIP6963Emitter.ts
@@ -11,6 +11,7 @@ export const EIP6963Emitter = () => {
       icon: config.walletIcon as any,
       name: config.walletName,
       rdns: config.eip6963.rdns,
+      uuid: config.environmentId,
     },
     provider: createEIP1193Provider(Wallet),
   });


### PR DESCRIPTION
updates the global-wallet-client package and use the env id as the eip-6963 uuid