### PR TITLE
feat: add native api to the global wallet

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "build:cjs": "tsc --project ./tsconfig.json --module commonjs --moduleResolution node --outDir ./dist/cjs --removeComments --verbatimModuleSyntax false"
   },
   "dependencies": {
-    "@dynamic-labs/global-wallet-client": "^4.9.9",
+    "@dynamic-labs/global-wallet-client": "^4.15.0",
     "@wallet-standard/wallet": "^1.1.0"
   },
   "devDependencies": {
@@ -53,11 +53,11 @@
   },
   "typesVersions": {
     "*": {
-      "eip6963": [
-        "./dist/types/eip6963.d.ts"
+      "ethereum": [
+        "./dist/types/ethereum.d.ts"
       ],
-      "solana-standard": [
-        "./dist/types/solana-standard.d.ts"
+      "solana": [
+        "./dist/types/solana.d.ts"
       ]
     }
   },
@@ -67,15 +67,15 @@
       "import": "./dist/esm/index.js",
       "default": "./dist/cjs/index.js"
     },
-    "./eip6963": {
-      "types": "./dist/types/eip6963.d.ts",
-      "import": "./dist/esm/eip6963.js",
-      "default": "./dist/cjs/eip6963.js"
+    "./ethereum": {
+      "types": "./dist/types/ethereum.d.ts",
+      "import": "./dist/esm/ethereum.js",
+      "default": "./dist/cjs/ethereum.js"
     },
-    "./solana-standard": {
-      "types": "./dist/types/solana-standard.d.ts",
-      "import": "./dist/esm/solana-standard.js",
-      "default": "./dist/cjs/solana-standard.js"
+    "./solana": {
+      "types": "./dist/types/solana.d.ts",
+      "import": "./dist/esm/solana.js",
+      "default": "./dist/cjs/solana.js"
     }
   }
 }

--- a/src/eip6963.ts
+++ b/src/eip6963.ts
@@ -1,3 +1,0 @@
-import { EIP6963Emitter } from "./lib/EIP6963Emitter";
-
-EIP6963Emitter();

--- a/src/ethereum.ts
+++ b/src/ethereum.ts
@@ -1,0 +1,5 @@
+import { EIP6963Emitter } from "./lib/EIP6963Emitter";
+
+EIP6963Emitter();
+
+export { createEIP1193Provider } from "@dynamic-labs/global-wallet-client/ethereum";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,5 @@
-export { registerSolanaStandard } from "./lib/registerSolanaStandard";
-export { EIP6963Emitter } from "./lib/EIP6963Emitter";
+import Wallet from "./lib/wallet";
+
+export * from "@dynamic-labs/global-wallet-client/features";
+
+export default Wallet;

--- a/src/solana.ts
+++ b/src/solana.ts
@@ -1,3 +1,5 @@
 import { registerSolanaStandard } from "./lib/registerSolanaStandard";
 
 registerSolanaStandard();
+
+export { createSolanaWallet } from "@dynamic-labs/global-wallet-client/solana";


### PR DESCRIPTION
Upgrade the global wallet template to also export the wallet features like:

- connect
- disconnect
- getEthereumEnabledNetworks
- switchNetwork
- onEvent
- signMessage
...


This also changes the exports names below

- ./eip6963 -> ./ethereum
- ./solana-standard -> ./solana

The functionality of these exports did not change, when importing the `ethereum` entry point will also emit the wallet provider via eip6963 and importing the `solana` entry point will also emit the wallet via solana standard