### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ After configuring your wallet package, test it locally using a Wallet SDK of you
 
    - For **Solana Wallet**:
      ```javascript
-     import "<wallet-package-name>/solana-standard";
+     import "<wallet-package-name>/solana";
      ```
 
 6. **Use Your Wallet**


### PR DESCRIPTION
hey, found a small mismatch in the readme

in the “Import Your Wallet” step it says:


`import "<wallet-package-name>/solana-standard";`


but the template’s package.json only exports:

`import "<wallet-package-name>/solana";`

so `/solana-standard` throws a module not found error

possible fixes:

update docs to `/solana`

or add an alias in the template’s exports so `/solana-standard` maps to the same file as `/solana`